### PR TITLE
udev rules: Fixed to resize vrtio-scsi disks

### DIFF
--- a/src/lib/udev/rules.d/65-context.rules##apk.one
+++ b/src/lib/udev/rules.d/65-context.rules##apk.one
@@ -10,7 +10,8 @@ SUBSYSTEM=="block", ACTION=="change", \
 
 # Handle disk resize
 SUBSYSTEM=="block", ACTION=="change", \
-  ENV{RESIZE}=="1", \
+  ENV{DEVTYPE}=="disk", \
+  ENV{ID_TYPE}=="disk", \
   RUN+="/sbin/service one-context-force restart"
 
 # Handle swap hot-attach

--- a/src/lib/udev/rules.d/65-context.rules##deb.one
+++ b/src/lib/udev/rules.d/65-context.rules##deb.one
@@ -14,7 +14,8 @@ SUBSYSTEM=="block", ACTION=="change", \
 
 # Handle disk resize
 SUBSYSTEM=="block", ACTION=="change", \
-  ENV{RESIZE}=="1", \
+  ENV{DEVTYPE}=="disk", \
+  ENV{ID_TYPE}=="disk", \
   RUN+="/usr/sbin/service one-context-force start"
 
 # Handle swap hot-attach

--- a/src/lib/udev/rules.d/65-context.rules##rpm.systemd.one
+++ b/src/lib/udev/rules.d/65-context.rules##rpm.systemd.one
@@ -9,7 +9,8 @@ SUBSYSTEM=="block", ACTION=="change", \
 
 # Handle disk resize
 SUBSYSTEM=="block", ACTION=="change", \
-  ENV{RESIZE}=="1", \
+  ENV{DEVTYPE}=="disk", \
+  ENV{ID_TYPE}=="disk", \
   RUN+="/bin/systemctl --no-block start one-context-force.service"
 
 # Handle swap hot-attach

--- a/src/lib/udev/rules.d/65-context.rules##rpm.sysv.one
+++ b/src/lib/udev/rules.d/65-context.rules##rpm.sysv.one
@@ -4,7 +4,8 @@ SUBSYSTEM=="net", ACTION=="add", \
 
 # Handle disk resize
 SUBSYSTEM=="block", ACTION=="change", \
-  ENV{RESIZE}=="1", \
+  ENV{DEVTYPE}=="disk", \
+  ENV{ID_TYPE}=="disk", \
   RUN+="/sbin/service one-context-force start"
 
 # Handle swap hot-attach


### PR DESCRIPTION
Original rule was trigger on resize of virtio-blk disks only. RESIZE
attribue is issued only for vd* disks. To be able to resize virtio-scsi
disks, ENV{RESIZE}==1 rule is replaced.

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->

Changes proposed in this pull request:
-
-
-
